### PR TITLE
Hotfix/chart

### DIFF
--- a/src/main/java/com/lifestockserver/lifestock/chart/repository/ChartRepository.java
+++ b/src/main/java/com/lifestockserver/lifestock/chart/repository/ChartRepository.java
@@ -19,31 +19,27 @@ public interface ChartRepository extends JpaRepository<Chart, Long> {
     Optional<Chart> findLatestAfterMarketOpenChartByCompanyId(@Param("companyId") Long companyId);
 
        @Query("SELECT c FROM Chart c " +
-              "JOIN (SELECT FUNCTION('DATE', c2.date) as chartDate, MAX(c2.date) as maxDate " +
+              "JOIN (SELECT c2.company.id as companyId, MAX(c2.createdAt) as latestCreatedAt " +
               "      FROM Chart c2 " +
               "      WHERE c2.company.id = :companyId AND c2.isAfterMarketOpen = true " +
-              "      GROUP BY FUNCTION('DATE', c2.date)) latestDates " +
-              "ON FUNCTION('DATE', c.date) = latestDates.chartDate " +
-              "AND c.date = latestDates.maxDate " +
+              "      GROUP BY c2.date) latestDates " +
+              "ON c.company.id = latestDates.companyId " +
+              "AND c.createdAt = latestDates.latestCreatedAt " +
               "WHERE c.company.id = :companyId AND c.isAfterMarketOpen = true " +
               "ORDER BY c.date DESC")
        Page<Chart> findLatestAfterMarketOpenChartPageByCompanyId(@Param("companyId") Long companyId, Pageable pageable);
 
        @Query("SELECT c FROM Chart c " +
-       "JOIN (SELECT FUNCTION('DATE', c2.date) as chartDate, MAX(c2.date) as maxDate " +
-       "      FROM Chart c2 " +
-       "      WHERE c2.company.id = :companyId " +
-       "      AND c2.isAfterMarketOpen = true " +
-       "      AND FUNCTION('YEAR', c2.date) = :year " +
-       "      AND FUNCTION('MONTH', c2.date) = :month " +
-       "      GROUP BY FUNCTION('DATE', c2.date)) latestDates " +
-       "ON FUNCTION('DATE', c.date) = latestDates.chartDate " +
-       "AND c.date = latestDates.maxDate " +
-       "WHERE c.company.id = :companyId " +
-       "AND c.isAfterMarketOpen = true " +
-       "AND FUNCTION('YEAR', c.date) = :year " +
-       "AND FUNCTION('MONTH', c.date) = :month " +
-       "ORDER BY c.date DESC")
+              "JOIN (SELECT c2.company.id as companyId, MAX(c2.createdAt) as latestCreatedAt " +
+              "      FROM Chart c2 " +
+              "      WHERE c2.company.id = :companyId AND c2.isAfterMarketOpen = true " +
+              "      AND FUNCTION('YEAR', c2.date) = :year " +
+              "      AND FUNCTION('MONTH', c2.date) = :month " +
+              "      GROUP BY c2.date) latestDates " +
+              "ON c.company.id = latestDates.companyId " +
+              "AND c.createdAt = latestDates.latestCreatedAt " +
+              "WHERE c.company.id = :companyId AND c.isAfterMarketOpen = true " +
+              "ORDER BY c.date DESC")
        List<Chart> findLatestAfterMarketOpenChartListByCompanyIdAndYearMonth(
        @Param("companyId") Long companyId,
        @Param("year") int year,


### PR DESCRIPTION
## 📝 Purpose of PR
chart를 불러올 때 같은 날에 대한 여러 차트 데이터가 반환되는 에러가 발생

### Contents
불러오는 기준이 chart.date이 같은 경우 가져오도록 해놨는데, chart.date이 같은 것을 그룹화 하고 그 중 createdAt이 가장 최신인 chart 1개를 select하는 것으로 수정


### Screenshots (Optional)


## 💬 Review Requirements (Optioanl)
If there is anything you would like the reviewer to pay special attention to, please write it down.
